### PR TITLE
Fix React act() warning in WeeklySchedule tests

### DIFF
--- a/src/__tests__/components/WeeklySchedule.test.tsx
+++ b/src/__tests__/components/WeeklySchedule.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { WeeklySchedule } from '@/components/WeeklySchedule'
 import { Task, TaskScheduleWithTask } from '@/lib/types'
 
@@ -180,7 +180,9 @@ describe('WeeklySchedule', () => {
       expect(screen.getAllByText('スケジュール生成')[0]).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getAllByText('スケジュール生成')[0])
+    await act(async () => {
+      fireEvent.click(screen.getAllByText('スケジュール生成')[0])
+    })
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('/api/schedule/generate', {


### PR DESCRIPTION
## Summary
- Fixed React `act()` warning in WeeklySchedule component tests
- Improved test reliability by properly handling async state updates

## Changes Made
- Added `act` import from `@testing-library/react`
- Wrapped `fireEvent.click` in `act()` to prevent state update warnings
- Ensured proper handling of async state updates during testing

## Test Results
- All 14 WeeklySchedule tests pass without warnings
- No breaking changes to existing functionality
- Improved test quality and reliability

## Test Plan
- [x] Run WeeklySchedule tests - all pass without warnings
- [x] Run full test suite - all 97 tests pass
- [x] Verify no regression in component behavior

🤖 Generated with [Claude Code](https://claude.ai/code)