### PR TITLE
feat: 長時間タスクの時間スロット表示を改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "task-tool",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.1.1",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
@@ -808,6 +811,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.1.1",
@@ -838,6 +839,20 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/sortable": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "test:ci": "jest --ci --coverage --watchAll=false"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.1.1",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.1.1",

--- a/src/__tests__/api/schedule-id.test.ts
+++ b/src/__tests__/api/schedule-id.test.ts
@@ -1,0 +1,472 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server'
+import { PUT } from '@/app/api/schedule/[id]/route'
+import { TaskService } from '@/lib/services/taskService'
+
+// TaskServiceのモック
+jest.mock('@/lib/services/taskService', () => ({
+  TaskService: {
+    updateTaskSchedule: jest.fn(),
+  },
+}))
+
+describe('/api/schedule/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('PUT', () => {
+    it('スケジュールを正常に更新できる', async () => {
+      const requestBody = {
+        start_time: '10:00',
+        end_time: '12:00',
+        scheduled_date: '2024-01-08'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.message).toBe('スケジュールが正常に更新されました')
+      expect(TaskService.updateTaskSchedule).toHaveBeenCalledWith(1, {
+        start_time: '10:00',
+        end_time: '12:00',
+        scheduled_date: '2024-01-08'
+      })
+    })
+
+    it('部分的な更新（開始時間のみ）ができる', async () => {
+      const requestBody = {
+        start_time: '09:00'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.message).toBe('スケジュールが正常に更新されました')
+      expect(TaskService.updateTaskSchedule).toHaveBeenCalledWith(1, {
+        start_time: '09:00'
+      })
+    })
+
+    it('部分的な更新（終了時間のみ）ができる', async () => {
+      const requestBody = {
+        end_time: '17:00'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.message).toBe('スケジュールが正常に更新されました')
+      expect(TaskService.updateTaskSchedule).toHaveBeenCalledWith(1, {
+        end_time: '17:00'
+      })
+    })
+
+    it('部分的な更新（日付のみ）ができる', async () => {
+      const requestBody = {
+        scheduled_date: '2024-01-09'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.message).toBe('スケジュールが正常に更新されました')
+      expect(TaskService.updateTaskSchedule).toHaveBeenCalledWith(1, {
+        scheduled_date: '2024-01-09'
+      })
+    })
+
+    it('無効なスケジュールIDの場合は400エラーを返す', async () => {
+      const requestBody = {
+        start_time: '10:00'
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/invalid', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: 'invalid' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('無効なスケジュールIDです')
+    })
+
+    it('更新するフィールドが指定されていない場合は400エラーを返す', async () => {
+      const requestBody = {}
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('更新するフィールドを指定してください')
+    })
+
+    it('無効な日付形式の場合は400エラーを返す', async () => {
+      const requestBody = {
+        scheduled_date: '2024/01/08' // 無効な形式
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('無効な日付形式です (YYYY-MM-DD)')
+    })
+
+    it('土曜日の日付は400エラーを返す', async () => {
+      const requestBody = {
+        scheduled_date: '2024-01-13' // 土曜日
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('営業日（月曜日から金曜日）のみ指定できます')
+    })
+
+    it('日曜日の日付は400エラーを返す', async () => {
+      const requestBody = {
+        scheduled_date: '2024-01-14' // 日曜日
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('営業日（月曜日から金曜日）のみ指定できます')
+    })
+
+    it('無効な開始時間形式の場合は400エラーを返す', async () => {
+      const requestBody = {
+        start_time: '25:00' // 無効な時間
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('無効な開始時間形式です (HH:MM)')
+    })
+
+    it('無効な終了時間形式の場合は400エラーを返す', async () => {
+      const requestBody = {
+        end_time: '12:60' // 無効な分
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('無効な終了時間形式です (HH:MM)')
+    })
+
+    it('開始時間が終了時間以降の場合は400エラーを返す', async () => {
+      const requestBody = {
+        start_time: '15:00',
+        end_time: '14:00' // 開始時間より前
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('開始時間は終了時間より前である必要があります')
+    })
+
+    it('開始時間と終了時間が同じ場合は400エラーを返す', async () => {
+      const requestBody = {
+        start_time: '10:00',
+        end_time: '10:00' // 同じ時間
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('開始時間は終了時間より前である必要があります')
+    })
+
+    it('存在しないスケジュールの更新は404エラーを返す', async () => {
+      const requestBody = {
+        start_time: '10:00'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(false)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/999', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '999' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('スケジュールが見つからないか、更新に失敗しました')
+      expect(TaskService.updateTaskSchedule).toHaveBeenCalledWith(999, {
+        start_time: '10:00'
+      })
+    })
+
+    it('JSONの解析に失敗した場合は500エラーを返す', async () => {
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: 'invalid json',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('サーバーエラーが発生しました')
+    })
+
+    it('営業日の境界値テスト - 月曜日（成功）', async () => {
+      const requestBody = {
+        scheduled_date: '2024-01-08' // 月曜日
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+
+      expect(response.status).toBe(200)
+    })
+
+    it('営業日の境界値テスト - 金曜日（成功）', async () => {
+      const requestBody = {
+        scheduled_date: '2024-01-12' // 金曜日
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+
+      expect(response.status).toBe(200)
+    })
+
+    it('時間の境界値テスト - 00:00（成功）', async () => {
+      const requestBody = {
+        start_time: '00:00',
+        end_time: '01:00'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+
+      expect(response.status).toBe(200)
+    })
+
+    it('時間の境界値テスト - 23:59（成功）', async () => {
+      const requestBody = {
+        start_time: '23:00',
+        end_time: '23:59'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/1', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '1' }) }
+      const response = await PUT(request, context)
+
+      expect(response.status).toBe(200)
+    })
+
+    it('数字のIDが文字列で渡された場合も正常に処理される', async () => {
+      const requestBody = {
+        start_time: '10:00'
+      }
+
+      ;(TaskService.updateTaskSchedule as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/123', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const context = { params: Promise.resolve({ id: '123' }) }
+      const response = await PUT(request, context)
+
+      expect(response.status).toBe(200)
+      expect(TaskService.updateTaskSchedule).toHaveBeenCalledWith(123, {
+        start_time: '10:00'
+      })
+    })
+  })
+})

--- a/src/__tests__/api/schedule-move.test.ts
+++ b/src/__tests__/api/schedule-move.test.ts
@@ -1,0 +1,481 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server'
+import { PUT } from '@/app/api/schedule/move/route'
+import { TaskService } from '@/lib/services/taskService'
+
+// TaskServiceのモック
+jest.mock('@/lib/services/taskService', () => ({
+  TaskService: {
+    getTaskById: jest.fn(),
+    moveTaskToDate: jest.fn(),
+    checkTimeConflicts: jest.fn(),
+  },
+}))
+
+describe('/api/schedule/move', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('PUT', () => {
+    it('タスクを正常に移動できる', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08',
+        targetTime: '10:00'
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 2,
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.message).toBe('タスクが正常に移動されました')
+      expect(TaskService.getTaskById).toHaveBeenCalledWith(1)
+      expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(
+        '2024-01-08',
+        '10:00',
+        '12:00', // 2時間後
+        1
+      )
+      expect(TaskService.moveTaskToDate).toHaveBeenCalledWith(1, '2024-01-08', '10:00')
+    })
+
+    it('時間指定なしでタスクを移動できる', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08'
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 1,
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(data.message).toBe('タスクが正常に移動されました')
+      expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(
+        '2024-01-08',
+        '09:00', // デフォルト時間
+        '10:00', // 1時間後
+        1
+      )
+      expect(TaskService.moveTaskToDate).toHaveBeenCalledWith(1, '2024-01-08', undefined)
+    })
+
+    it('必須パラメーターが不足している場合は400エラーを返す', async () => {
+      const requestBody = {
+        targetDate: '2024-01-08'
+        // taskId が不足
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('taskId と targetDate は必須です')
+    })
+
+    it('無効な日付形式の場合は400エラーを返す', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024/01/08' // 無効な形式
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('無効な日付形式です (YYYY-MM-DD)')
+    })
+
+    it('無効な時間形式の場合は400エラーを返す', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08',
+        targetTime: '25:00' // 無効な時間
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('無効な時間形式です (HH:MM)')
+    })
+
+    it('土曜日への移動は400エラーを返す', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-13' // 土曜日
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('営業日（月曜日から金曜日）のみ指定できます')
+    })
+
+    it('日曜日への移動は400エラーを返す', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-14' // 日曜日
+      }
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(data.error).toBe('営業日（月曜日から金曜日）のみ指定できます')
+    })
+
+    it('存在しないタスクの場合は404エラーを返す', async () => {
+      const requestBody = {
+        taskId: 999,
+        targetDate: '2024-01-08'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(null)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(404)
+      expect(data.error).toBe('タスクが見つかりません')
+      expect(TaskService.getTaskById).toHaveBeenCalledWith(999)
+    })
+
+    it('時間競合がある場合は409エラーを返す', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08',
+        targetTime: '10:00'
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 2,
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(409)
+      expect(data.error).toBe('指定された時間帯に他のタスクが既にスケジュールされています')
+      expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(
+        '2024-01-08',
+        '10:00',
+        '12:00',
+        1
+      )
+      expect(TaskService.moveTaskToDate).not.toHaveBeenCalled()
+    })
+
+    it('タスクの移動に失敗した場合は500エラーを返す', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08'
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 1,
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(false)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('タスクの移動に失敗しました')
+      expect(TaskService.moveTaskToDate).toHaveBeenCalledWith(1, '2024-01-08', undefined)
+    })
+
+    it('estimated_hoursが未設定の場合はデフォルト値を使用する', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08',
+        targetTime: '10:00'
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: undefined, // 未設定
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(
+        '2024-01-08',
+        '10:00',
+        '11:00', // デフォルト1時間後
+        1
+      )
+    })
+
+    it('JSONの解析に失敗した場合は500エラーを返す', async () => {
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: 'invalid json',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+      const data = await response.json()
+
+      expect(response.status).toBe(500)
+      expect(data.error).toBe('サーバーエラーが発生しました')
+    })
+
+    it('境界値のテスト - 小数の見積もり時間', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08',
+        targetTime: '10:00'
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 1.5, // 小数
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+
+      expect(response.status).toBe(200)
+      expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(
+        '2024-01-08',
+        '10:00',
+        '11:30', // 1.5時間後
+        1
+      )
+    })
+
+    it('営業日の境界値テスト - 月曜日（成功）', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-08' // 月曜日
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 1,
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+
+      expect(response.status).toBe(200)
+    })
+
+    it('営業日の境界値テスト - 金曜日（成功）', async () => {
+      const requestBody = {
+        taskId: 1,
+        targetDate: '2024-01-12' // 金曜日
+      }
+
+      const mockTask = {
+        id: 1,
+        title: 'テストタスク',
+        priority: 'must',
+        estimated_hours: 1,
+        status: 'pending',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-01T00:00:00Z'
+      }
+
+      ;(TaskService.getTaskById as jest.Mock).mockReturnValue(mockTask)
+      ;(TaskService.checkTimeConflicts as jest.Mock).mockReturnValue(false)
+      ;(TaskService.moveTaskToDate as jest.Mock).mockReturnValue(true)
+
+      const request = new NextRequest('http://localhost:3000/api/schedule/move', {
+        method: 'PUT',
+        body: JSON.stringify(requestBody),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const response = await PUT(request)
+
+      expect(response.status).toBe(200)
+    })
+  })
+})

--- a/src/__tests__/api/schedule-move.test.ts
+++ b/src/__tests__/api/schedule-move.test.ts
@@ -100,8 +100,8 @@ describe('/api/schedule/move', () => {
       expect(data.message).toBe('タスクが正常に移動されました')
       expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(
         '2024-01-08',
-        '09:00', // デフォルト時間
-        '10:00', // 1時間後
+        '10:00', // デフォルト時間
+        '11:00', // 1時間後
         1
       )
       expect(TaskService.moveTaskToDate).toHaveBeenCalledWith(1, '2024-01-08', undefined)

--- a/src/__tests__/api/schedule-move.test.ts
+++ b/src/__tests__/api/schedule-move.test.ts
@@ -345,7 +345,6 @@ describe('/api/schedule/move', () => {
       })
 
       const response = await PUT(request)
-      const data = await response.json()
 
       expect(response.status).toBe(200)
       expect(TaskService.checkTimeConflicts).toHaveBeenCalledWith(

--- a/src/__tests__/components/WeeklySchedule.test.tsx
+++ b/src/__tests__/components/WeeklySchedule.test.tsx
@@ -46,8 +46,8 @@ describe('WeeklySchedule', () => {
       {
         task_id: 1,
         day_of_week: 1,
-        start_time: '09:00',
-        end_time: '13:00',
+        start_time: '10:00',
+        end_time: '14:00',
         scheduled_date: '2024-01-08',
         title: 'プレゼンテーション資料作成',
         description: '来週の会議用プレゼンテーション資料を作成する',
@@ -152,7 +152,7 @@ describe('WeeklySchedule', () => {
 
       // スケジュール済みタスクの表示
       expect(screen.getByText('プレゼンテーション資料作成')).toBeInTheDocument()
-      expect(screen.getByText('09:00 - 13:00')).toBeInTheDocument()
+      expect(screen.getByText('10:00 - 14:00')).toBeInTheDocument()
 
       // 各日の予定時間
       expect(screen.getByText('4.0時間')).toBeInTheDocument()

--- a/src/__tests__/services/taskService.test.ts
+++ b/src/__tests__/services/taskService.test.ts
@@ -871,8 +871,8 @@ describe('TaskService', () => {
       expect(statements.insertTaskSchedule.run).toHaveBeenCalledWith(
         taskId,
         2, // 火曜日
-        '09:00', // デフォルト時間
-        '10:30', // 1.5時間後
+        '10:00', // デフォルト時間
+        '11:30', // 1.5時間後
         targetDate
       )
       expect(result).toBe(true)
@@ -923,8 +923,8 @@ describe('TaskService', () => {
       expect(statements.insertTaskSchedule.run).toHaveBeenCalledWith(
         taskId,
         1, // 月曜日
-        '09:00',
-        '10:00', // デフォルト1時間
+        '10:00',
+        '11:00', // デフォルト1時間
         targetDate
       )
       expect(result).toBe(true)

--- a/src/app/api/schedule/[id]/route.ts
+++ b/src/app/api/schedule/[id]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { TaskService } from '@/lib/services/taskService';
+
+export async function PUT(
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) {
+  try {
+    const params = await context.params;
+    const scheduleId = parseInt(params.id);
+    
+    if (isNaN(scheduleId)) {
+      return NextResponse.json(
+        { error: '無効なスケジュールIDです' },
+        { status: 400 }
+      );
+    }
+
+    const { start_time, end_time, scheduled_date } = await request.json();
+
+    // 少なくとも1つのフィールドが更新対象である必要がある
+    if (!start_time && !end_time && !scheduled_date) {
+      return NextResponse.json(
+        { error: '更新するフィールドを指定してください' },
+        { status: 400 }
+      );
+    }
+
+    // 日付の形式チェック
+    if (scheduled_date) {
+      const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+      if (!dateRegex.test(scheduled_date)) {
+        return NextResponse.json(
+          { error: '無効な日付形式です (YYYY-MM-DD)' },
+          { status: 400 }
+        );
+      }
+
+      // 営業日チェック（月曜日から金曜日のみ）
+      const targetDay = new Date(scheduled_date).getDay();
+      if (targetDay === 0 || targetDay === 6) {
+        return NextResponse.json(
+          { error: '営業日（月曜日から金曜日）のみ指定できます' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // 時間の形式チェック
+    if (start_time) {
+      const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+      if (!timeRegex.test(start_time)) {
+        return NextResponse.json(
+          { error: '無効な開始時間形式です (HH:MM)' },
+          { status: 400 }
+        );
+      }
+    }
+
+    if (end_time) {
+      const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+      if (!timeRegex.test(end_time)) {
+        return NextResponse.json(
+          { error: '無効な終了時間形式です (HH:MM)' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // 開始時間と終了時間の論理チェック
+    if (start_time && end_time && start_time >= end_time) {
+      return NextResponse.json(
+        { error: '開始時間は終了時間より前である必要があります' },
+        { status: 400 }
+      );
+    }
+
+    // スケジュールの更新
+    const success = TaskService.updateTaskSchedule(scheduleId, {
+      start_time,
+      end_time,
+      scheduled_date
+    });
+
+    if (success) {
+      return NextResponse.json(
+        { message: 'スケジュールが正常に更新されました' },
+        { status: 200 }
+      );
+    } else {
+      return NextResponse.json(
+        { error: 'スケジュールが見つからないか、更新に失敗しました' },
+        { status: 404 }
+      );
+    }
+  } catch (error) {
+    console.error('スケジュール更新エラー:', error);
+    return NextResponse.json(
+      { error: 'サーバーエラーが発生しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/schedule/generate/route.ts
+++ b/src/app/api/schedule/generate/route.ts
@@ -104,7 +104,7 @@ async function saveScheduleToDatabase(schedule: { [key: string]: Task[] }) {
     const adjustedDay = dayOfWeek === 0 ? 7 : dayOfWeek; // Convert Sunday from 0 to 7
     
     if (adjustedDay >= 1 && adjustedDay <= 5) { // Monday to Friday
-      let currentTime = 9; // Start at 9 AM
+      let currentTime = 10; // Start at 10 AM
       
       for (const task of tasks) {
         const estimatedHours = task.estimated_hours || 2;

--- a/src/app/api/schedule/move/route.ts
+++ b/src/app/api/schedule/move/route.ts
@@ -52,7 +52,7 @@ export async function PUT(request: NextRequest) {
     }
 
     // 時間競合チェック
-    const startTime = targetTime || '09:00';
+    const startTime = targetTime || '10:00';
     const estimatedHours = task.estimated_hours || 1;
     const [startHour, startMinute] = startTime.split(':').map(Number);
     const endHour = startHour + Math.floor(estimatedHours);

--- a/src/app/api/schedule/move/route.ts
+++ b/src/app/api/schedule/move/route.ts
@@ -55,8 +55,11 @@ export async function PUT(request: NextRequest) {
     const startTime = targetTime || '10:00';
     const estimatedHours = task.estimated_hours || 1;
     const [startHour, startMinute] = startTime.split(':').map(Number);
-    const endHour = startHour + Math.floor(estimatedHours);
-    const endMinute = startMinute + ((estimatedHours % 1) * 60);
+    
+    // 終了時間の計算（分のオーバーフロー処理）
+    const totalMinutes = startMinute + ((estimatedHours % 1) * 60);
+    const endHour = startHour + Math.floor(estimatedHours) + Math.floor(totalMinutes / 60);
+    const endMinute = Math.round(totalMinutes % 60);
     const endTime = `${endHour.toString().padStart(2, '0')}:${endMinute.toString().padStart(2, '0')}`;
 
     // 時間競合チェック

--- a/src/app/api/schedule/move/route.ts
+++ b/src/app/api/schedule/move/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { TaskService } from '@/lib/services/taskService';
+
+export async function PUT(request: NextRequest) {
+  try {
+    const { taskId, targetDate, targetTime } = await request.json();
+
+    // 入力値の検証
+    if (!taskId || !targetDate) {
+      return NextResponse.json(
+        { error: 'taskId と targetDate は必須です' },
+        { status: 400 }
+      );
+    }
+
+    // 日付の形式チェック
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
+    if (!dateRegex.test(targetDate)) {
+      return NextResponse.json(
+        { error: '無効な日付形式です (YYYY-MM-DD)' },
+        { status: 400 }
+      );
+    }
+
+    // 時間の形式チェック（オプション）
+    if (targetTime) {
+      const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+      if (!timeRegex.test(targetTime)) {
+        return NextResponse.json(
+          { error: '無効な時間形式です (HH:MM)' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // 営業日チェック（月曜日から金曜日のみ）
+    const targetDay = new Date(targetDate).getDay();
+    if (targetDay === 0 || targetDay === 6) {
+      return NextResponse.json(
+        { error: '営業日（月曜日から金曜日）のみ指定できます' },
+        { status: 400 }
+      );
+    }
+
+    // タスクの存在チェック
+    const task = TaskService.getTaskById(taskId);
+    if (!task) {
+      return NextResponse.json(
+        { error: 'タスクが見つかりません' },
+        { status: 404 }
+      );
+    }
+
+    // 時間競合チェック
+    const startTime = targetTime || '09:00';
+    const estimatedHours = task.estimated_hours || 1;
+    const [startHour, startMinute] = startTime.split(':').map(Number);
+    const endHour = startHour + Math.floor(estimatedHours);
+    const endMinute = startMinute + ((estimatedHours % 1) * 60);
+    const endTime = `${endHour.toString().padStart(2, '0')}:${endMinute.toString().padStart(2, '0')}`;
+
+    // 時間競合チェック
+    if (TaskService.checkTimeConflicts(targetDate, startTime, endTime, taskId)) {
+      return NextResponse.json(
+        { error: '指定された時間帯に他のタスクが既にスケジュールされています' },
+        { status: 409 }
+      );
+    }
+
+    // タスクを移動
+    const success = TaskService.moveTaskToDate(taskId, targetDate, targetTime);
+    
+    if (success) {
+      return NextResponse.json(
+        { message: 'タスクが正常に移動されました' },
+        { status: 200 }
+      );
+    } else {
+      return NextResponse.json(
+        { error: 'タスクの移動に失敗しました' },
+        { status: 500 }
+      );
+    }
+  } catch (error) {
+    console.error('タスク移動エラー:', error);
+    return NextResponse.json(
+      { error: 'サーバーエラーが発生しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/WeeklySchedule.tsx
+++ b/src/components/WeeklySchedule.tsx
@@ -4,12 +4,300 @@ import { useState, useEffect } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Clock, Calendar, RefreshCw } from 'lucide-react';
+import { Clock, Calendar, RefreshCw, GripVertical } from 'lucide-react';
 import { Task, TaskScheduleWithTask, DAYS_OF_WEEK } from '@/lib/types';
 import { getISOWeekDates } from '@/lib/utils';
+import {
+  DndContext,
+  DragOverlay,
+  DragStartEvent,
+  DragEndEvent,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import {
+  useDraggable,
+  useDroppable,
+} from '@dnd-kit/core';
 
 interface WeeklyScheduleProps {
   tasks: Task[];
+}
+
+// ドラッグ可能なタスクカード
+interface DraggableTaskProps {
+  task: TaskScheduleWithTask & {
+    isFirstSlot?: boolean;
+    isContinuation?: boolean;
+    totalHours?: number;
+  };
+  isDragging?: boolean;
+}
+
+function DraggableTask({ task, isDragging = false }: DraggableTaskProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging: isActiveDragging,
+  } = useDraggable({
+    id: `task-${task.task_id}`,
+    data: { task },
+  });
+
+  const style = transform ? {
+    transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+  } : undefined;
+
+  const getPriorityColor = (priority: 'must' | 'want') => {
+    return priority === 'must' ? 'bg-red-100 text-red-800' : 'bg-blue-100 text-blue-800';
+  };
+
+  // 継続中のタスクの場合は簡素化された表示
+  if (task.isContinuation) {
+    return (
+      <div
+        ref={setNodeRef}
+        style={style}
+        {...attributes}
+        className={`p-2 bg-gray-100 rounded border-l-4 border-gray-400 cursor-move transition-all ${
+          isActiveDragging ? 'opacity-50 scale-95' : ''
+        } ${isDragging ? 'opacity-50' : ''}`}
+      >
+        <div className="flex items-center gap-2">
+          <div
+            {...listeners}
+            className="text-gray-400 hover:text-gray-600 cursor-grab active:cursor-grabbing"
+          >
+            <GripVertical className="w-3 h-3" />
+          </div>
+          <div className="flex-1">
+            <div className="text-xs text-gray-600 italic">
+              {task.title} (継続中)
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      className={`p-3 bg-gray-50 rounded-lg border cursor-move transition-all ${
+        isActiveDragging ? 'opacity-50 scale-95' : ''
+      } ${isDragging ? 'opacity-50' : ''} ${
+        task.totalHours && task.totalHours > 1 ? 'border-l-4 border-blue-400' : ''
+      }`}
+    >
+      <div className="flex items-start gap-2">
+        <div
+          {...listeners}
+          className="mt-1 text-gray-400 hover:text-gray-600 cursor-grab active:cursor-grabbing"
+        >
+          <GripVertical className="w-4 h-4" />
+        </div>
+        <div className="flex-1">
+          <div className="font-medium text-sm mb-1">
+            {task.title}
+            {task.totalHours && task.totalHours > 1 && (
+              <span className="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-1 rounded">
+                {task.totalHours}h
+              </span>
+            )}
+          </div>
+          <div className="flex items-center justify-between">
+            <Badge className={getPriorityColor(task.priority)}>
+              {task.priority === 'must' ? '必須' : '希望'}
+            </Badge>
+            {task.estimated_hours && (
+              <div className="flex items-center gap-1 text-xs text-gray-600">
+                <Clock className="w-3 h-3" />
+                <span>{task.estimated_hours}h</span>
+              </div>
+            )}
+          </div>
+          {task.start_time && task.end_time && (
+            <div className="text-xs text-gray-500 mt-1">
+              {task.start_time} - {task.end_time}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ドロップ可能な時間スロット
+interface DroppableTimeSlotProps {
+  date: string;
+  time: string;
+  children: React.ReactNode;
+  isOccupied: boolean;
+}
+
+function DroppableTimeSlot({ date, time, children, isOccupied }: DroppableTimeSlotProps) {
+  const { isOver, setNodeRef } = useDroppable({
+    id: `slot-${date}-${time}`,
+    data: { date, time },
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`min-h-12 p-2 rounded border-2 border-dashed transition-all ${
+        isOver && !isOccupied 
+          ? 'border-blue-500 bg-blue-50' 
+          : isOccupied 
+          ? 'border-gray-200 bg-gray-50' 
+          : 'border-gray-300 hover:border-gray-400'
+      }`}
+    >
+      <div className="text-xs text-gray-500 mb-1">{time}</div>
+      {children}
+    </div>
+  );
+}
+
+// ドロップ可能な日付カード
+interface DroppableDayProps {
+  date: string;
+  scheduledTasks: TaskScheduleWithTask[];
+  getDateLabel: (date: string) => string;
+  getTotalHours: (date: string) => number;
+  activeId: string | null;
+}
+
+function DroppableDay({ date, scheduledTasks, getDateLabel, getTotalHours, activeId }: DroppableDayProps) {
+  // 1時間単位の時間スロットを生成（9:00-18:00）
+  const timeSlots = Array.from({ length: 9 }, (_, i) => {
+    const hour = 9 + i;
+    return `${hour.toString().padStart(2, '0')}:00`;
+  });
+
+  // 各時間スロットのタスクを取得
+  const getTasksForTimeSlot = (time: string) => {
+    return scheduledTasks.filter(task => {
+      if (!task.start_time) return false;
+      const taskStartHour = parseInt(task.start_time.split(':')[0]);
+      const slotHour = parseInt(time.split(':')[0]);
+      const taskEndHour = task.end_time ? parseInt(task.end_time.split(':')[0]) : taskStartHour + 1;
+      return taskStartHour <= slotHour && slotHour < taskEndHour;
+    }).map(task => {
+      const taskStartHour = parseInt(task.start_time!.split(':')[0]);
+      const slotHour = parseInt(time.split(':')[0]);
+      const taskEndHour = task.end_time ? parseInt(task.end_time.split(':')[0]) : taskStartHour + 1;
+      
+      // 初回表示かどうかを判定
+      const isFirstSlot = taskStartHour === slotHour;
+      // 継続中かどうかを判定
+      const isContinuation = taskStartHour < slotHour;
+      
+      return {
+        ...task,
+        isFirstSlot,
+        isContinuation,
+        totalHours: taskEndHour - taskStartHour
+      };
+    });
+  };
+
+  return (
+    <Card className="min-h-96">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">
+          {getDateLabel(date)}
+        </CardTitle>
+        <div className="text-xs text-gray-500">
+          {getTotalHours(date).toFixed(1)}時間
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-1">
+        {timeSlots.map((time) => {
+          const slotTasks = getTasksForTimeSlot(time);
+          const isOccupied = slotTasks.length > 0;
+          
+          return (
+            <DroppableTimeSlot
+              key={time}
+              date={date}
+              time={time}
+              isOccupied={isOccupied}
+            >
+              {slotTasks.map((task) => (
+                <DraggableTask
+                  key={`${task.task_id}-${task.id}-${time}`}
+                  task={task}
+                  isDragging={activeId === `task-${task.task_id}`}
+                />
+              ))}
+            </DroppableTimeSlot>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ドラッグ可能な未スケジュールタスク
+interface DraggableUnscheduledTaskProps {
+  task: Task;
+}
+
+function DraggableUnscheduledTask({ task }: DraggableUnscheduledTaskProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: `unscheduled-${task.id}`,
+    data: { task, isUnscheduled: true },
+  });
+
+  const style = transform ? {
+    transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+  } : undefined;
+
+  const getPriorityColor = (priority: 'must' | 'want') => {
+    return priority === 'must' ? 'bg-red-100 text-red-800' : 'bg-blue-100 text-blue-800';
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      className={`flex items-center justify-between p-3 bg-gray-50 rounded cursor-move ${
+        isDragging ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <div
+          {...listeners}
+          className="text-gray-400 hover:text-gray-600 cursor-grab active:cursor-grabbing"
+        >
+          <GripVertical className="w-4 h-4" />
+        </div>
+        <span className="font-medium">{task.title}</span>
+        <Badge className={getPriorityColor(task.priority)}>
+          {task.priority === 'must' ? '必須' : '希望'}
+        </Badge>
+      </div>
+      {task.estimated_hours && (
+        <div className="flex items-center gap-1 text-sm text-gray-600">
+          <Clock className="w-4 h-4" />
+          <span>{task.estimated_hours}h</span>
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
@@ -17,6 +305,17 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
   const [currentWeek, setCurrentWeek] = useState<string[]>([]);
   const [isGenerating, setIsGenerating] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [draggedTask, setDraggedTask] = useState<TaskScheduleWithTask | Task | null>(null);
+
+  // ドラッグ&ドロップ用のセンサー設定
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    })
+  );
 
   useEffect(() => {
     generateCurrentWeek();
@@ -66,6 +365,85 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
     }
   };
 
+  // ドラッグ&ドロップイベントハンドラー
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+    const data = event.active.data.current;
+    if (data?.task) {
+      setDraggedTask(data.task);
+    }
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    
+    if (!over) {
+      setActiveId(null);
+      setDraggedTask(null);
+      return;
+    }
+
+    const activeData = active.data.current;
+    const overData = over.data.current;
+
+    if (!activeData?.task || !overData?.date) {
+      setActiveId(null);
+      setDraggedTask(null);
+      return;
+    }
+
+    const task = activeData.task;
+    const targetDate = overData.date;
+    const targetTime = overData.time; // 時間スロット情報を取得
+
+    try {
+      let taskId: number;
+      
+      if (activeData.isUnscheduled) {
+        // 未スケジュールタスクの場合
+        taskId = task.id;
+      } else {
+        // 既存のスケジュールタスクの場合
+        taskId = task.task_id;
+      }
+
+      const requestBody: {
+        taskId: number;
+        targetDate: string;
+        targetTime?: string;
+      } = {
+        taskId,
+        targetDate,
+      };
+
+      // 時間スロットが指定されている場合は時間を追加
+      if (targetTime) {
+        requestBody.targetTime = targetTime;
+      }
+
+      const response = await fetch('/api/schedule/move', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (response.ok) {
+        await fetchWeeklySchedule();
+      } else {
+        const errorData = await response.json();
+        alert(errorData.error || 'タスクの移動に失敗しました');
+      }
+    } catch (error) {
+      console.error('タスク移動エラー:', error);
+      alert('タスクの移動に失敗しました');
+    }
+
+    setActiveId(null);
+    setDraggedTask(null);
+  };
+
   const getDateLabel = (dateString: string) => {
     const date = new Date(dateString);
     const dayOfWeek = date.getDay();
@@ -100,15 +478,21 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
   }
 
   return (
-    <div className="space-y-6">
-      {/* ヘッダー */}
-      <div className="flex justify-between items-center">
-        <h2 className="text-xl font-semibold">週間スケジュール</h2>
-        <Button onClick={generateSchedule} disabled={isGenerating}>
-          <RefreshCw className={`w-4 h-4 mr-2 ${isGenerating ? 'animate-spin' : ''}`} />
-          {isGenerating ? 'スケジュール生成中...' : 'スケジュール生成'}
-        </Button>
-      </div>
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="space-y-6">
+        {/* ヘッダー */}
+        <div className="flex justify-between items-center">
+          <h2 className="text-xl font-semibold">週間スケジュール</h2>
+          <Button onClick={generateSchedule} disabled={isGenerating}>
+            <RefreshCw className={`w-4 h-4 mr-2 ${isGenerating ? 'animate-spin' : ''}`} />
+            {isGenerating ? 'スケジュール生成中...' : 'スケジュール生成'}
+          </Button>
+        </div>
 
       {/* 統計情報 */}
       <div className="grid grid-cols-3 gap-4 mb-6">
@@ -147,20 +531,7 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
           <CardContent>
             <div className="space-y-2">
               {getUnscheduledTasks().map((task) => (
-                <div key={task.id} className="flex items-center justify-between p-3 bg-gray-50 rounded">
-                  <div className="flex items-center gap-3">
-                    <span className="font-medium">{task.title}</span>
-                    <Badge className={getPriorityColor(task.priority)}>
-                      {task.priority === 'must' ? '必須' : '希望'}
-                    </Badge>
-                  </div>
-                  {task.estimated_hours && (
-                    <div className="flex items-center gap-1 text-sm text-gray-600">
-                      <Clock className="w-4 h-4" />
-                      <span>{task.estimated_hours}h</span>
-                    </div>
-                  )}
-                </div>
+                <DraggableUnscheduledTask key={task.id} task={task} />
               ))}
             </div>
           </CardContent>
@@ -170,44 +541,14 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
       {/* 週間カレンダー */}
       <div className="grid grid-cols-5 gap-4">
         {currentWeek.map((date) => (
-          <Card key={date} className="min-h-96">
-            <CardHeader className="pb-3">
-              <CardTitle className="text-sm">
-                {getDateLabel(date)}
-              </CardTitle>
-              <div className="text-xs text-gray-500">
-                {getTotalHours(date).toFixed(1)}時間
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              {(weeklySchedule[date] || []).map((scheduleTask) => (
-                <div
-                  key={`${scheduleTask.task_id}-${scheduleTask.id}`}
-                  className="p-3 bg-gray-50 rounded-lg border"
-                >
-                  <div className="font-medium text-sm mb-1">
-                    {scheduleTask.title}
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <Badge className={getPriorityColor(scheduleTask.priority)}>
-                      {scheduleTask.priority === 'must' ? '必須' : '希望'}
-                    </Badge>
-                    {scheduleTask.estimated_hours && (
-                      <div className="flex items-center gap-1 text-xs text-gray-600">
-                        <Clock className="w-3 h-3" />
-                        <span>{scheduleTask.estimated_hours}h</span>
-                      </div>
-                    )}
-                  </div>
-                  {scheduleTask.start_time && scheduleTask.end_time && (
-                    <div className="text-xs text-gray-500 mt-1">
-                      {scheduleTask.start_time} - {scheduleTask.end_time}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </CardContent>
-          </Card>
+          <DroppableDay
+            key={date}
+            date={date}
+            scheduledTasks={weeklySchedule[date] || []}
+            getDateLabel={getDateLabel}
+            getTotalHours={getTotalHours}
+            activeId={activeId}
+          />
         ))}
       </div>
 
@@ -224,6 +565,29 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
           </CardContent>
         </Card>
       )}
-    </div>
+      </div>
+      
+      {/* ドラッグオーバーレイ */}
+      <DragOverlay>
+        {activeId && draggedTask ? (
+          <div className="p-3 bg-white rounded-lg border shadow-lg">
+            <div className="font-medium text-sm mb-1">
+              {draggedTask.title}
+            </div>
+            <div className="flex items-center justify-between">
+              <Badge className={getPriorityColor(draggedTask.priority)}>
+                {draggedTask.priority === 'must' ? '必須' : '希望'}
+              </Badge>
+              {draggedTask.estimated_hours && (
+                <div className="flex items-center gap-1 text-xs text-gray-600">
+                  <Clock className="w-3 h-3" />
+                  <span>{draggedTask.estimated_hours}h</span>
+                </div>
+              )}
+            </div>
+          </div>
+        ) : null}
+      </DragOverlay>
+    </DndContext>
   );
 }

--- a/src/components/WeeklySchedule.tsx
+++ b/src/components/WeeklySchedule.tsx
@@ -12,7 +12,7 @@ import {
   DragOverlay,
   DragStartEvent,
   DragEndEvent,
-  closestCenter,
+  pointerWithin,
   PointerSensor,
   useSensor,
   useSensors,
@@ -21,6 +21,7 @@ import {
   useDraggable,
   useDroppable,
 } from '@dnd-kit/core';
+import { snapCenterToCursor } from '@dnd-kit/modifiers';
 
 interface WeeklyScheduleProps {
   tasks: Task[];
@@ -312,7 +313,7 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
   const sensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: {
-        distance: 8,
+        distance: 3,
       },
     })
   );
@@ -480,7 +481,7 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
   return (
     <DndContext
       sensors={sensors}
-      collisionDetection={closestCenter}
+      collisionDetection={pointerWithin}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >
@@ -568,10 +569,10 @@ export function WeeklySchedule({ tasks }: WeeklyScheduleProps) {
       </div>
       
       {/* ドラッグオーバーレイ */}
-      <DragOverlay>
+      <DragOverlay modifiers={[snapCenterToCursor]}>
         {activeId && draggedTask ? (
-          <div className="p-3 bg-white rounded-lg border shadow-lg">
-            <div className="font-medium text-sm mb-1">
+          <div className="p-3 bg-white rounded-lg border shadow-lg max-w-64">
+            <div className="font-medium text-sm mb-1 truncate">
               {draggedTask.title}
             </div>
             <div className="flex items-center justify-between">

--- a/src/components/WeeklySchedule.tsx
+++ b/src/components/WeeklySchedule.tsx
@@ -175,9 +175,9 @@ interface DroppableDayProps {
 }
 
 function DroppableDay({ date, scheduledTasks, getDateLabel, getTotalHours, activeId }: DroppableDayProps) {
-  // 1時間単位の時間スロットを生成（9:00-18:00）
-  const timeSlots = Array.from({ length: 9 }, (_, i) => {
-    const hour = 9 + i;
+  // 1時間単位の時間スロットを生成（10:00-19:00）
+  const timeSlots = Array.from({ length: 10 }, (_, i) => {
+    const hour = 10 + i;
     return `${hour.toString().padStart(2, '0')}:00`;
   });
 

--- a/src/components/WeeklySchedule.tsx
+++ b/src/components/WeeklySchedule.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -185,6 +185,20 @@ function DroppableDay({ date, scheduledTasks, getDateLabel, getTotalHours, activ
     return `${i.toString().padStart(2, '0')}:00`;
   });
 
+  // スクロール位置を10時に設定するためのref
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      // 10時の位置にスクロール
+      const tenOClockIndex = 10;
+      const slotHeight = 48; // min-h-12 (3rem = 48px)
+      const padding = 4; // space-y-1
+      const scrollTop = tenOClockIndex * (slotHeight + padding);
+      scrollRef.current.scrollTop = scrollTop;
+    }
+  }, []);
+
   // 営業時間帯（10:00-19:00）かどうかを判定
   const isBusinessHour = (time: string) => {
     const hour = parseInt(time.split(':')[0]);
@@ -219,7 +233,7 @@ function DroppableDay({ date, scheduledTasks, getDateLabel, getTotalHours, activ
   };
 
   return (
-    <Card className="h-96 flex flex-col">
+    <Card className="h-[600px] flex flex-col">
       <CardHeader className="pb-3 flex-shrink-0">
         <CardTitle className="text-sm">
           {getDateLabel(date)}
@@ -228,7 +242,7 @@ function DroppableDay({ date, scheduledTasks, getDateLabel, getTotalHours, activ
           {getTotalHours(date).toFixed(1)}時間
         </div>
       </CardHeader>
-      <CardContent className="flex-1 overflow-y-auto space-y-1">
+      <CardContent ref={scrollRef} className="flex-1 overflow-y-auto space-y-1" style={{ scrollBehavior: 'smooth' }}>
         {timeSlots.map((time) => {
           const slotTasks = getTasksForTimeSlot(time);
           const isOccupied = slotTasks.length > 0;

--- a/src/lib/database/db.ts
+++ b/src/lib/database/db.ts
@@ -122,6 +122,25 @@ export const statements = {
       DELETE FROM task_schedules 
       WHERE scheduled_date BETWEEN ? AND ?
     `);
+  },
+
+  // 個別タスクのスケジュール削除
+  get deleteTaskSchedule() {
+    return getDatabase().prepare(`
+      DELETE FROM task_schedules 
+      WHERE task_id = ?
+    `);
+  },
+
+  // 個別スケジュールの更新
+  get updateTaskSchedule() {
+    return getDatabase().prepare(`
+      UPDATE task_schedules 
+      SET start_time = COALESCE(?, start_time),
+          end_time = COALESCE(?, end_time),
+          scheduled_date = COALESCE(?, scheduled_date)
+      WHERE id = ?
+    `);
   }
 };
 

--- a/src/lib/services/taskService.ts
+++ b/src/lib/services/taskService.ts
@@ -133,10 +133,11 @@ export class TaskService {
         const task = this.getTaskById(taskId);
         const estimatedHours = task?.estimated_hours || 1;
         
-        // 終了時間を計算
+        // 終了時間を計算（分のオーバーフロー処理）
         const [startHour, startMinute] = startTime.split(':').map(Number);
-        const endHour = startHour + Math.floor(estimatedHours);
-        const endMinute = startMinute + ((estimatedHours % 1) * 60);
+        const totalMinutes = startMinute + ((estimatedHours % 1) * 60);
+        const endHour = startHour + Math.floor(estimatedHours) + Math.floor(totalMinutes / 60);
+        const endMinute = Math.round(totalMinutes % 60);
         const endTime = `${endHour.toString().padStart(2, '0')}:${endMinute.toString().padStart(2, '0')}`;
         
         statements.insertTaskSchedule.run(

--- a/src/lib/services/taskService.ts
+++ b/src/lib/services/taskService.ts
@@ -129,7 +129,7 @@ export class TaskService {
       const adjustedDayOfWeek = dayOfWeek === 0 ? 7 : dayOfWeek;
       
       if (adjustedDayOfWeek >= 1 && adjustedDayOfWeek <= 5) {
-        const startTime = targetTime || '09:00';
+        const startTime = targetTime || '10:00';
         const task = this.getTaskById(taskId);
         const estimatedHours = task?.estimated_hours || 1;
         


### PR DESCRIPTION
## Summary
- 長時間タスクの時間スロット表示を改善
- 週間スケジュール表示を0-24時の24時間表示に拡張
- ドラッグ&ドロップ時のカーソル位置ずれ問題を修正
- スケジュール生成の開始時間を10時に修正
- 時間スロット表示を10時-19時の営業時間に変更
- 初期表示を10時からに変更し、カードの高さを600pxに拡張

## Test plan
- [x] 長時間タスクが複数の時間スロットにまたがって正しく表示されることを確認
- [x] 24時間表示で全時間帯が利用可能であることを確認
- [x] ドラッグ&ドロップ操作でカーソル位置が正確に追従することを確認
- [x] スケジュール生成で10時から開始される営業時間設定を確認
- [x] 週間スケジュールの初期表示が10時から開始されることを確認
- [x] 表示領域の拡張により視認性が向上したことを確認

## Related Issue

-  Issue #13 

🤖 Generated with [Claude Code](https://claude.ai/code)