### PR TITLE
feat: Dependabot reviewers設定をCODEOWNERSに移行

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @shirochan

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 10
-    reviewers:
-      - "@shirochan"
     commit-message:
       prefix: "deps"
       include: "scope"
@@ -20,8 +18,6 @@ updates:
       day: "monday"
       time: "09:00"
     open-pull-requests-limit: 5
-    reviewers:
-      - "@shirochan"
     commit-message:
       prefix: "docker"
       include: "scope"


### PR DESCRIPTION
## Summary
- GitHub Code Owners機能を使用してDependabotのレビュアー設定を置き換え
- 2025年5月20日に廃止予定の`reviewers`設定を事前に削除
- `.github/CODEOWNERS`ファイルを作成し、すべてのファイルに対して`@shirochan`をレビュアーとして設定

## Changes
- `.github/CODEOWNERS`ファイルを新規作成
- `.github/dependabot.yml`から`reviewers`セクションを削除

## Background
GitHub blogの告知に従い、Dependabotの`reviewers`設定機能がCode Owners機能に統合されるため、事前に移行を実施。

参考: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Test plan
- [x] CODEOWNERSファイルの作成
- [x] dependabot.ymlの更新
- [ ] PRが作成されレビュアーが自動的に割り当てられることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)