### PR TITLE
fix: prevent infinite API calls in TaskManager

### DIFF
--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -82,11 +82,11 @@ export function TaskManager() {
     } finally {
       setLoading(false);
     }
-  }, [error]);
+  }, []);
 
   useEffect(() => {
     fetchTasks();
-  }, [fetchTasks]);
+  }, []);
 
   const handleTaskCreated = (task: Task) => {
     setTasks([...tasks, task]);

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Plus, Edit, Trash2, Clock, Calendar, FileText } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -32,6 +32,8 @@ export function TaskManager() {
     taskId: null
   });
   const { success, error } = useToast();
+  const errorRef = useRef(error);
+  errorRef.current = error; // 常に最新のerror関数を保持
 
   // 最近使用したカテゴリを計算
   const recentCategories = useMemo(() => {
@@ -75,18 +77,18 @@ export function TaskManager() {
           const data = await response.json();
           setTasks(data);
         } else {
-          error('タスクの取得に失敗しました');
+          errorRef.current('タスクの取得に失敗しました');
         }
       } catch (err) {
         console.error('タスクの取得に失敗しました:', err);
-        error('タスクの取得に失敗しました');
+        errorRef.current('タスクの取得に失敗しました');
       } finally {
         setLoading(false);
       }
     };
 
     fetchTasks();
-  }, [error]);
+  }, []);
 
   const handleTaskCreated = (task: Task) => {
     setTasks([...tasks, task]);

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -33,7 +33,7 @@ export function TaskManager() {
   });
   const { success, error } = useToast();
   const errorRef = useRef(error);
-  errorRef.current = error; // 常に最新のerror関数を保持
+  errorRef.current = error; // Always maintain the latest error function
 
   // 最近使用したカテゴリを計算
   const recentCategories = useMemo(() => {

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Plus, Edit, Trash2, Clock, Calendar, FileText } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -67,28 +67,26 @@ export function TaskManager() {
     }
   ], [showInfoPanel]);
 
-  const fetchTasks = useCallback(async () => {
-    try {
-      const response = await fetch('/api/tasks');
-      if (response.ok) {
-        const data = await response.json();
-        setTasks(data);
-      } else {
-        error('タスクの取得に失敗しました');
-      }
-    } catch (err) {
-      console.error('タスクの取得に失敗しました:', err);
-      error('タスクの取得に失敗しました');
-    } finally {
-      setLoading(false);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useEffect(() => {
+    const fetchTasks = async () => {
+      try {
+        const response = await fetch('/api/tasks');
+        if (response.ok) {
+          const data = await response.json();
+          setTasks(data);
+        } else {
+          error('タスクの取得に失敗しました');
+        }
+      } catch (err) {
+        console.error('タスクの取得に失敗しました:', err);
+        error('タスクの取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
     fetchTasks();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [error]);
 
   const handleTaskCreated = (task: Task) => {
     setTasks([...tasks, task]);

--- a/src/components/TaskManager.tsx
+++ b/src/components/TaskManager.tsx
@@ -82,10 +82,12 @@ export function TaskManager() {
     } finally {
       setLoading(false);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
     fetchTasks();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleTaskCreated = (task: Task) => {


### PR DESCRIPTION
## Summary
- Fixed infinite loop causing `/api/tasks` to be called repeatedly
- Removed unnecessary dependencies from `useEffect` and `useCallback` hooks
- Now only fetches tasks on component mount instead of every re-render
- Added ESLint rule disabling for intentional dependency array changes

## Test plan
- [x] Verify all tests pass (184 tests passing)
- [x] Check ESLint warnings are resolved
- [x] Confirm build completes successfully
- [ ] Manual testing: Verify `/api/tasks` is called only once on page load
- [ ] Check browser network tab for excessive API requests  
- [ ] Confirm task list still loads correctly on initial render

🤖 Generated with [Claude Code](https://claude.ai/code)