### PR TITLE
fix: dependabotの月次実行設定を修正

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 15
@@ -16,7 +15,6 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-      day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
     open-pull-requests-limit: 8


### PR DESCRIPTION
## Summary
- dependabot.ymlから`day: "monday"`設定を削除
- 月次実行時に毎週実行される問題を解決
- GitHubが月初の適切なタイミングで自動実行するように修正

## Test plan
- [ ] PRマージ後、dependabotが月次のみ実行されることを確認
- [ ] 次回の実行タイミングがGitHub側で適切に設定されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)